### PR TITLE
Adds tests to increase coverage to 100% of parser states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ lint:
 test:
 	go test ./... -race
 .PHONY: test
+
+generate:
+	go run golang.org/x/tools/cmd/goyacc@master -l -o yy_parser.go grammar.y
+.PHONY: generate

--- a/grammar.y
+++ b/grammar.y
@@ -341,7 +341,7 @@ table_alias:
   }
 | STRING
   {
-    $$ = Identifier(string($1))
+    $$ = Identifier(string($1[1:len($1)-1]))
   }
 ;
 

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -1239,7 +1239,7 @@ yydefault:
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			yyVAL.identifier = Identifier(string(yyDollar[1].bytes))
+			yyVAL.identifier = Identifier(string(yyDollar[1].bytes[1 : len(yyDollar[1].bytes)-1]))
 		}
 	case 42:
 		yyDollar = yyS[yypt-4 : yypt+1]


### PR DESCRIPTION
States 193, 163, 158, 41, 36, 35, 28, and 25 were not being covered. One test was added for each of them.
And a bug was found on state 41. Single quotes were not excluded.

Here's how I approached this task:
- I've run a coverage test to see which states from the `yy_parser.go` (generated parser from the grammar) were not being reached. By state, I mean a case in the big switch statement that exists there. 
- I found that cases 193, 163, 158, 41, 36, 35, 28, and 25 were not covered by any test
- I used the `y.output` parse table to find out from which grammar rule the case was generated
- From that, I created a test in `parser_test.go`
- I discovered a bug in state 41

Results, now 100% of the states are being tested.