### PR TITLE
Adds syntax diagrams generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ test:
 generate:
 	go run golang.org/x/tools/cmd/goyacc@master -l -o yy_parser.go grammar.y
 .PHONY: generate
+
+# requires java
+generate-diagrams:
+	go run ebnf/main.go grammar.y | java -jar rr/rr.war -suppressebnf -color:#FFFFFF -out:diagrams.xhtml -
+.PHONY: generate-diagrams

--- a/README.md
+++ b/README.md
@@ -59,5 +59,7 @@ Resulting AST:
 ## Generating syntax diagrams
 
 ```bash
-make generate-diagrams
+make generate-diagrams 
 ```
+
+Requires Java 8 (or higher).

--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ Resulting AST:
  })
 })
  ```
+
+## Generating syntax diagrams
+
+```bash
+make generate-diagrams
+```

--- a/diagrams.xhtml
+++ b/diagrams.xhtml
@@ -1,0 +1,3995 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <meta name="generator" content="Railroad Diagram Generator 1.63" />
+      <style type="text/css">
+    ::-moz-selection
+    {
+      color: #FFFFFF;
+      background: #141414;
+    }
+    ::selection
+    {
+      color: #FFFFFF;
+      background: #141414;
+    }
+    .ebnf a, .grammar a
+    {
+      text-decoration: none;
+    }
+    .ebnf a:hover, .grammar a:hover
+    {
+      color: #0F0F0F;
+      text-decoration: underline;
+    }
+    .signature
+    {
+      color: #4D4D4D;
+      font-size: 11px;
+      text-align: right;
+    }
+    body
+    {
+      font: normal 12px Verdana, sans-serif;
+      color: #141414;
+      background: #FFFFFF;
+    }
+    a:link, a:visited
+    {
+      color: #141414;
+    }
+    a:link.signature, a:visited.signature
+    {
+      color: #4D4D4D;
+    }
+    a.button, #tabs li a
+    {
+      padding: 0.25em 0.5em;
+      border: 1px solid #4D4D4D;
+      background: #E3E3E3;
+      color: #4D4D4D;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    a.button:hover, #tabs li a:hover
+    {
+      color: #0F0F0F;
+      background: #F0F0F0;
+      border-color: #0F0F0F;
+    }
+    #tabs
+    {
+      padding: 3px 10px;
+      margin-left: 0;
+      margin-top: 58px;
+      border-bottom: 1px solid #141414;
+    }
+    #tabs li
+    {
+      list-style: none;
+      margin-left: 5px;
+      display: inline;
+    }
+    #tabs li a
+    {
+      border-bottom: 1px solid #141414;
+    }
+    #tabs li a.active
+    {
+      color: #141414;
+      background: #FFFFFF;
+      border-color: #141414;
+      border-bottom: 1px solid #FFFFFF;
+      outline: none;
+    }
+    #divs div
+    {
+      display: none;
+      overflow:auto;
+    }
+    #divs div.active
+    {
+      display: block;
+    }
+    #text
+    {
+      border-color: #4D4D4D;
+      background: #FFFFFF;
+      color: #0F0F0F;
+    }
+    .small
+    {
+      vertical-align: top;
+      text-align: right;
+      font-size: 9px;
+      font-weight: normal;
+      line-height: 120%;
+    }
+    td.small
+    {
+      padding-top: 0px;
+    }
+    .hidden
+    {
+      visibility: hidden;
+    }
+    td:hover .hidden
+    {
+      visibility: visible;
+    }
+    div.download
+    {
+      display: none;
+      background: #FFFFFF;
+      position: absolute;
+      right: 34px;
+      top: 94px;
+      padding: 10px;
+      border: 1px dotted #141414;
+    }
+    #divs div.ebnf, .ebnf code
+    {
+      display: block;
+      padding: 10px;
+      background: #F0F0F0;
+      width: 992px;
+    }
+    #divs div.grammar
+    {
+      display: block;
+      padding-left: 16px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+      background: #F0F0F0;
+    }
+    pre
+    {
+      margin: 0px;
+    }
+    .ebnf div
+    {
+      padding-left: 13ch;
+      text-indent: -13ch;
+    }
+    .ebnf code, .grammar code, textarea, pre
+    {
+      font:12px SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+    }
+    tr.option-line td:first-child
+    {
+      text-align: right
+    }
+    tr.option-text td
+    {
+      padding-bottom: 10px
+    }
+    table.palette
+    {
+      border-top: 1px solid #0F0F0F;
+      border-right: 1px solid #0F0F0F;
+      margin-bottom: 4px
+    }
+    td.palette
+    {
+      border-bottom: 1px solid #0F0F0F;
+      border-left: 1px solid #0F0F0F;
+    }
+    a.palette
+    {
+      padding: 2px 3px 2px 10px;
+      text-decoration: none;
+    }
+    .palette
+    {
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -o-user-select: none;
+      -ms-user-select: none;
+    }
+  </style><svg xmlns="http://www.w3.org/2000/svg">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs></svg></head>
+   <body>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="start">start:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="115" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#stmts" xlink:title="stmts">
+            <rect x="31" y="3" width="56" height="32"></rect>
+            <rect x="29" y="1" width="56" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">stmts</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="105 17 113 13 113 21"></polygon>
+         <polygon points="105 17 97 13 97 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">no references</xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="stmts">stmts:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="359" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#single_stmt" xlink:title="single_stmt">
+            <rect x="51" y="3" width="94" height="32"></rect>
+            <rect x="49" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">single_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#multi_stmt" xlink:title="multi_stmt">
+            <rect x="71" y="91" width="88" height="32"></rect>
+            <rect x="69" y="89" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="109">multi_stmt</text></a><rect x="71" y="47" width="24" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">;</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#semicolon_opt" xlink:title="semicolon_opt">
+            <rect x="219" y="3" width="112" height="32"></rect>
+            <rect x="217" y="1" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="227" y="21">semicolon_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m94 0 h10 m0 0 h34 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v68 m168 0 v-68 m-168 68 q0 10 10 10 m148 0 q10 0 10 -10 m-138 10 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m40 -44 h10 m112 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="349 17 357 13 357 21"></polygon>
+         <polygon points="349 17 341 13 341 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#start" title="start">start</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="single_stmt">single_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="235" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="51" y="3" width="94" height="32"></rect>
+            <rect x="49" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">select_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#create_table_stmt" xlink:title="create_table_stmt">
+            <rect x="51" y="47" width="136" height="32"></rect>
+            <rect x="49" y="45" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">create_table_stmt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m94 0 h10 m0 0 h42 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m136 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="225 17 233 13 233 21"></polygon>
+         <polygon points="225 17 217 13 217 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#stmts" title="stmts">stmts</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="multi_stmt">multi_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="201" height="213">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#insert_stmt" xlink:title="insert_stmt">
+            <rect x="51" y="3" width="92" height="32"></rect>
+            <rect x="49" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">insert_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#delete_stmt" xlink:title="delete_stmt">
+            <rect x="51" y="47" width="96" height="32"></rect>
+            <rect x="49" y="45" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">delete_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#update_stmt" xlink:title="update_stmt">
+            <rect x="51" y="91" width="102" height="32"></rect>
+            <rect x="49" y="89" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">update_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#grant_stmt" xlink:title="grant_stmt">
+            <rect x="51" y="135" width="90" height="32"></rect>
+            <rect x="49" y="133" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">grant_stmt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#revoke_stmt" xlink:title="revoke_stmt">
+            <rect x="51" y="179" width="100" height="32"></rect>
+            <rect x="49" y="177" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">revoke_stmt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h10 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m96 0 h10 m0 0 h6 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m90 0 h10 m0 0 h12 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m100 0 h10 m0 0 h2 m23 -176 h-3"></svg:path>
+         <polygon points="191 17 199 13 199 21"></polygon>
+         <polygon points="191 17 183 13 183 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#stmts" title="stmts">stmts</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="semicolon_opt">semicolon_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="123" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">;</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h34 m-64 0 h20 m44 0 h20 m-84 0 q10 0 10 10 m64 0 q0 -10 10 -10 m-74 10 v12 m64 0 v-12 m-64 12 q0 10 10 10 m44 0 q10 0 10 -10 m-54 10 h10 m24 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="113 5 121 1 121 9"></polygon>
+         <polygon points="113 5 105 1 105 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#stmts" title="stmts">stmts</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="select_stmt">select_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="991" height="147">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SELECT" xlink:title="SELECT">
+            <rect x="31" y="47" width="66" height="32"></rect>
+            <rect x="29" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="65">SELECT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#distinct_opt" xlink:title="distinct_opt">
+            <rect x="117" y="47" width="94" height="32"></rect>
+            <rect x="115" y="45" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="125" y="65">distinct_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#select_column" xlink:title="select_column">
+            <rect x="251" y="47" width="110" height="32"></rect>
+            <rect x="249" y="45" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="259" y="65">select_column</text></a><rect x="251" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="249" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#from_clause" xlink:title="from_clause">
+            <rect x="401" y="47" width="96" height="32"></rect>
+            <rect x="399" y="45" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="409" y="65">from_clause</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_opt" xlink:title="where_opt">
+            <rect x="517" y="47" width="88" height="32"></rect>
+            <rect x="515" y="45" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="525" y="65">where_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#group_by_opt" xlink:title="group_by_opt">
+            <rect x="625" y="47" width="108" height="32"></rect>
+            <rect x="623" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="633" y="65">group_by_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#having_opt" xlink:title="having_opt">
+            <rect x="753" y="47" width="90" height="32"></rect>
+            <rect x="751" y="45" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="761" y="65">having_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#order_by_opt" xlink:title="order_by_opt">
+            <rect x="863" y="47" width="106" height="32"></rect>
+            <rect x="861" y="45" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="871" y="65">order_by_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#limit_opt" xlink:title="limit_opt">
+            <rect x="887" y="113" width="76" height="32"></rect>
+            <rect x="885" y="111" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="895" y="131">limit_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m0 0 h10 m66 0 h10 m0 0 h10 m94 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m20 44 h10 m96 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m106 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-126 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="981 127 989 123 989 131"></polygon>
+         <polygon points="981 127 973 123 973 131"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#single_stmt" title="single_stmt">single_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#subquery" title="subquery">subquery</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_expr" title="table_expr">table_expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="distinct_opt">distinct_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="177" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DISTINCT" xlink:title="DISTINCT">
+            <rect x="51" y="23" width="78" height="32"></rect>
+            <rect x="49" y="21" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">DISTINCT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ALL" xlink:title="ALL">
+            <rect x="51" y="67" width="42" height="32"></rect>
+            <rect x="49" y="65" width="42" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="85">ALL</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m42 0 h10 m0 0 h36 m23 -76 h-3"></svg:path>
+         <polygon points="167 5 175 1 175 9"></polygon>
+         <polygon points="167 5 159 1 159 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="select_column">select_column:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="327" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="71" y="35" width="96" height="32"></rect>
+            <rect x="69" y="33" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="53">table_name</text></a><rect x="187" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="185" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="53">.</text>
+         <rect x="251" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="249" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="21">*</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="51" y="79" width="48" height="32"></rect>
+            <rect x="49" y="77" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="97">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_column_opt" xlink:title="as_column_opt">
+            <rect x="119" y="79" width="116" height="32"></rect>
+            <rect x="117" y="77" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="127" y="97">as_column_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m40 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m96 0 h10 m0 0 h10 m24 0 h10 m20 -32 h10 m28 0 h10 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v56 m268 0 v-56 m-268 56 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m48 0 h10 m0 0 h10 m116 0 h10 m0 0 h44 m23 -76 h-3"></svg:path>
+         <polygon points="317 17 325 13 325 21"></polygon>
+         <polygon points="317 17 309 13 309 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="as_column_opt">as_column_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="269" height="89">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AS" xlink:title="AS">
+            <rect x="71" y="55" width="36" height="32"></rect>
+            <rect x="69" y="53" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="73">AS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#col_alias" xlink:title="col_alias">
+            <rect x="147" y="23" width="74" height="32"></rect>
+            <rect x="145" y="21" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="41">col_alias</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h180 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v12 m210 0 v-12 m-210 12 q0 10 10 10 m190 0 q10 0 10 -10 m-180 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m74 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="259 5 267 1 267 9"></polygon>
+         <polygon points="259 5 251 1 251 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_column" title="select_column">select_column</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="col_alias">col_alias:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="175" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="51" y="3" width="76" height="32"></rect>
+            <rect x="49" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">identifier</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="47" width="66" height="32"></rect>
+            <rect x="49" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m66 0 h10 m0 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="165 17 173 13 173 21"></polygon>
+         <polygon points="165 17 157 13 157 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#as_column_opt" title="as_column_opt">as_column_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="from_clause">from_clause:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="287" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FROM" xlink:title="FROM">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">FROM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_expr_list" xlink:title="table_expr_list">
+            <rect x="125" y="3" width="114" height="32"></rect>
+            <rect x="123" y="1" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="133" y="21">table_expr_list</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#join_clause" xlink:title="join_clause">
+            <rect x="125" y="47" width="92" height="32"></rect>
+            <rect x="123" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="133" y="65">join_clause</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m20 0 h10 m114 0 h10 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m92 0 h10 m0 0 h22 m23 -44 h-3"></svg:path>
+         <polygon points="277 17 285 13 285 21"></polygon>
+         <polygon points="277 17 269 13 269 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_expr_list">table_expr_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="187" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_expr" xlink:title="table_expr">
+            <rect x="51" y="47" width="88" height="32"></rect>
+            <rect x="49" y="45" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">table_expr</text></a><rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m23 44 h-3"></svg:path>
+         <polygon points="177 61 185 57 185 65"></polygon>
+         <polygon points="177 61 169 57 169 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#from_clause" title="from_clause">from_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_expr" title="table_expr">table_expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_expr">table_expr:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="449" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="51" y="3" width="96" height="32"></rect>
+            <rect x="49" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_table_opt" xlink:title="as_table_opt">
+            <rect x="167" y="3" width="104" height="32"></rect>
+            <rect x="165" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="175" y="21">as_table_opt</text></a><rect x="51" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="117" y="47" width="94" height="32"></rect>
+            <rect x="115" y="45" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="125" y="65">select_stmt</text></a><rect x="231" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="229" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="239" y="65">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#as_table_opt" xlink:title="as_table_opt">
+            <rect x="277" y="47" width="104" height="32"></rect>
+            <rect x="275" y="45" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="285" y="65">as_table_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_expr_list" xlink:title="table_expr_list">
+            <rect x="137" y="91" width="114" height="32"></rect>
+            <rect x="135" y="89" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="145" y="109">table_expr_list</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#join_clause" xlink:title="join_clause">
+            <rect x="137" y="135" width="92" height="32"></rect>
+            <rect x="135" y="133" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="145" y="153">join_clause</text></a><rect x="291" y="91" width="26" height="32" rx="10"></rect>
+         <rect x="289" y="89" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="299" y="109">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m96 0 h10 m0 0 h10 m104 0 h10 m0 0 h130 m-390 0 h20 m370 0 h20 m-410 0 q10 0 10 10 m390 0 q0 -10 10 -10 m-400 10 v24 m390 0 v-24 m-390 24 q0 10 10 10 m370 0 q10 0 10 -10 m-380 10 h10 m26 0 h10 m20 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m104 0 h10 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-274 10 h10 m114 0 h10 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m92 0 h10 m0 0 h22 m20 -44 h10 m26 0 h10 m0 0 h64 m43 -88 h-3"></svg:path>
+         <polygon points="439 17 447 13 447 21"></polygon>
+         <polygon points="439 17 431 13 431 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#join_clause" title="join_clause">join_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_expr_list" title="table_expr_list">table_expr_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="as_table_opt">as_table_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="285" height="89">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AS" xlink:title="AS">
+            <rect x="71" y="55" width="36" height="32"></rect>
+            <rect x="69" y="53" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="73">AS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_alias" xlink:title="table_alias">
+            <rect x="147" y="23" width="90" height="32"></rect>
+            <rect x="145" y="21" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="41">table_alias</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-196 10 h10 m0 0 h46 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v12 m76 0 v-12 m-76 12 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m20 -32 h10 m90 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="275 5 283 1 283 9"></polygon>
+         <polygon points="275 5 267 1 267 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#table_expr" title="table_expr">table_expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_alias">table_alias:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="175" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="51" y="3" width="76" height="32"></rect>
+            <rect x="49" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">identifier</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="47" width="66" height="32"></rect>
+            <rect x="49" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">STRING</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m66 0 h10 m0 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="165 17 173 13 173 21"></polygon>
+         <polygon points="165 17 157 13 157 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#as_table_opt" title="as_table_opt">as_table_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="join_clause">join_clause:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="497" height="53">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_expr" xlink:title="table_expr">
+            <rect x="31" y="19" width="88" height="32"></rect>
+            <rect x="29" y="17" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="37">table_expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#JOIN" xlink:title="JOIN">
+            <rect x="159" y="19" width="48" height="32"></rect>
+            <rect x="157" y="17" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="37">JOIN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_expr" xlink:title="table_expr">
+            <rect x="227" y="19" width="88" height="32"></rect>
+            <rect x="225" y="17" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="235" y="37">table_expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#join_constraint" xlink:title="join_constraint">
+            <rect x="335" y="19" width="114" height="32"></rect>
+            <rect x="333" y="17" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="343" y="37">join_constraint</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m88 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m114 0 h10 m-330 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m310 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-310 0 h10 m0 0 h300 m23 32 h-3"></svg:path>
+         <polygon points="487 33 495 29 495 37"></polygon>
+         <polygon points="487 33 479 29 479 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#from_clause" title="from_clause">from_clause</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_expr" title="table_expr">table_expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="join_constraint">join_constraint:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="405" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ON" xlink:title="ON">
+            <rect x="51" y="23" width="38" height="32"></rect>
+            <rect x="49" y="21" width="38" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">ON</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="109" y="23" width="48" height="32"></rect>
+            <rect x="107" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="117" y="41">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#USING" xlink:title="USING">
+            <rect x="51" y="67" width="60" height="32"></rect>
+            <rect x="49" y="65" width="60" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="85">USING</text></a><rect x="131" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="129" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="139" y="85">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name_list" xlink:title="column_name_list">
+            <rect x="177" y="67" width="134" height="32"></rect>
+            <rect x="175" y="65" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="185" y="85">column_name_list</text></a><rect x="331" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="329" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="339" y="85">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h316 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v12 m346 0 v-12 m-346 12 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m38 0 h10 m0 0 h10 m48 0 h10 m0 0 h200 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m60 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m26 0 h10 m23 -76 h-3"></svg:path>
+         <polygon points="395 5 403 1 403 9"></polygon>
+         <polygon points="395 5 387 1 387 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#join_clause" title="join_clause">join_clause</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="where_opt">where_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="233" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#WHERE" xlink:title="WHERE">
+            <rect x="51" y="23" width="66" height="32"></rect>
+            <rect x="49" y="21" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">WHERE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="137" y="23" width="48" height="32"></rect>
+            <rect x="135" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="145" y="41">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m66 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="223 5 231 1 231 9"></polygon>
+         <polygon points="223 5 215 1 215 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#delete_stmt" title="delete_stmt">delete_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#update_stmt" title="update_stmt">update_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="group_by_opt">group_by_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="313" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GROUP" xlink:title="GROUP">
+            <rect x="51" y="23" width="64" height="32"></rect>
+            <rect x="49" y="21" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">GROUP</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BY" xlink:title="BY">
+            <rect x="135" y="23" width="36" height="32"></rect>
+            <rect x="133" y="21" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="41">BY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="191" y="23" width="74" height="32"></rect>
+            <rect x="189" y="21" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="199" y="41">expr_list</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m64 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m74 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="303 5 311 1 311 9"></polygon>
+         <polygon points="303 5 295 1 295 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="having_opt">having_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="235" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#HAVING" xlink:title="HAVING">
+            <rect x="51" y="23" width="68" height="32"></rect>
+            <rect x="49" y="21" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">HAVING</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="139" y="23" width="48" height="32"></rect>
+            <rect x="137" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="41">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m68 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="225 5 233 1 233 9"></polygon>
+         <polygon points="225 5 217 1 217 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="order_by_opt">order_by_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="387" height="97">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ORDER" xlink:title="ORDER">
+            <rect x="51" y="47" width="62" height="32"></rect>
+            <rect x="49" y="45" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">ORDER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BY" xlink:title="BY">
+            <rect x="133" y="47" width="36" height="32"></rect>
+            <rect x="131" y="45" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="141" y="65">BY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ordering_term" xlink:title="ordering_term">
+            <rect x="209" y="47" width="110" height="32"></rect>
+            <rect x="207" y="45" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="65">ordering_term</text></a><rect x="209" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="207" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m62 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m-308 44 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v14 m328 0 v-14 m-328 14 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m0 0 h298 m23 -34 h-3"></svg:path>
+         <polygon points="377 61 385 57 385 65"></polygon>
+         <polygon points="377 61 369 57 369 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="ordering_term">ordering_term:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="303" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="31" y="3" width="48" height="32"></rect>
+            <rect x="29" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#asc_desc_opt" xlink:title="asc_desc_opt">
+            <rect x="99" y="3" width="106" height="32"></rect>
+            <rect x="97" y="1" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="107" y="21">asc_desc_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#nulls" xlink:title="nulls">
+            <rect x="225" y="3" width="50" height="32"></rect>
+            <rect x="223" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="21">nulls</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="293 17 301 13 301 21"></polygon>
+         <polygon points="293 17 285 13 285 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#order_by_opt" title="order_by_opt">order_by_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="asc_desc_opt">asc_desc_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="153" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ASC" xlink:title="ASC">
+            <rect x="51" y="23" width="44" height="32"></rect>
+            <rect x="49" y="21" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">ASC</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DESC" xlink:title="DESC">
+            <rect x="51" y="67" width="54" height="32"></rect>
+            <rect x="49" y="65" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="85">DESC</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m44 0 h10 m0 0 h10 m-84 -10 v20 m94 0 v-20 m-94 20 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m23 -76 h-3"></svg:path>
+         <polygon points="143 5 151 1 151 9"></polygon>
+         <polygon points="143 5 135 1 135 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#ordering_term" title="ordering_term">ordering_term</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="nulls">nulls:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="273" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NULLS" xlink:title="NULLS">
+            <rect x="51" y="23" width="60" height="32"></rect>
+            <rect x="49" y="21" width="60" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">NULLS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FIRST" xlink:title="FIRST">
+            <rect x="151" y="23" width="54" height="32"></rect>
+            <rect x="149" y="21" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="159" y="41">FIRST</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LAST" xlink:title="LAST">
+            <rect x="151" y="67" width="50" height="32"></rect>
+            <rect x="149" y="65" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="159" y="85">LAST</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m60 0 h10 m20 0 h10 m54 0 h10 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m50 0 h10 m0 0 h4 m43 -76 h-3"></svg:path>
+         <polygon points="263 5 271 1 271 9"></polygon>
+         <polygon points="263 5 255 1 255 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#ordering_term" title="ordering_term">ordering_term</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="limit_opt">limit_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="455" height="133">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LIMIT" xlink:title="LIMIT">
+            <rect x="51" y="23" width="54" height="32"></rect>
+            <rect x="49" y="21" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">LIMIT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="125" y="23" width="48" height="32"></rect>
+            <rect x="123" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="133" y="41">expr</text></a><rect x="233" y="55" width="24" height="32" rx="10"></rect>
+         <rect x="231" y="53" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="73">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OFFSET" xlink:title="OFFSET">
+            <rect x="233" y="99" width="66" height="32"></rect>
+            <rect x="231" y="97" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="117">OFFSET</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="339" y="55" width="48" height="32"></rect>
+            <rect x="337" y="53" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="347" y="73">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h366 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v12 m396 0 v-12 m-396 12 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m54 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-184 10 h10 m24 0 h10 m0 0 h42 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m20 -44 h10 m48 0 h10 m43 -64 h-3"></svg:path>
+         <polygon points="445 5 453 1 453 9"></polygon>
+         <polygon points="445 5 437 1 437 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#select_stmt" title="select_stmt">select_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_name">table_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="135" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="31" y="3" width="76" height="32"></rect>
+            <rect x="29" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">identifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="125 17 133 13 133 21"></polygon>
+         <polygon points="125 17 117 13 117 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#delete_stmt" title="delete_stmt">delete_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#grant_stmt" title="grant_stmt">grant_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#insert_stmt" title="insert_stmt">insert_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#select_column" title="select_column">select_column</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_expr" title="table_expr">table_expr</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#update_stmt" title="update_stmt">update_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="expr">expr:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="673" height="1739">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#literal_value" xlink:title="literal_value">
+            <rect x="51" y="3" width="98" height="32"></rect>
+            <rect x="49" y="1" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">literal_value</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="71" y="79" width="96" height="32"></rect>
+            <rect x="69" y="77" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="97">table_name</text></a><rect x="187" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="185" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="97">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name" xlink:title="column_name">
+            <rect x="251" y="47" width="108" height="32"></rect>
+            <rect x="249" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="259" y="65">column_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="51" y="123" width="48" height="32"></rect>
+            <rect x="49" y="121" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="141">expr</text></a><rect x="159" y="123" width="30" height="32" rx="10"></rect>
+         <rect x="157" y="121" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="141">+</text>
+         <rect x="159" y="167" width="26" height="32" rx="10"></rect>
+         <rect x="157" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="185">-</text>
+         <rect x="159" y="211" width="28" height="32" rx="10"></rect>
+         <rect x="157" y="209" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="229">*</text>
+         <rect x="159" y="255" width="28" height="32" rx="10"></rect>
+         <rect x="157" y="253" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="273">/</text>
+         <rect x="159" y="299" width="20" height="32" rx="10"></rect>
+         <rect x="157" y="297" width="20" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="317"></text>
+         <rect x="159" y="343" width="30" height="32" rx="10"></rect>
+         <rect x="157" y="341" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="361">&amp;</text>
+         <rect x="159" y="387" width="26" height="32" rx="10"></rect>
+         <rect x="157" y="385" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="405">|</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LSHIFT" xlink:title="LSHIFT">
+            <rect x="159" y="431" width="62" height="32"></rect>
+            <rect x="157" y="429" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="449">LSHIFT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RSHIFT" xlink:title="RSHIFT">
+            <rect x="159" y="475" width="64" height="32"></rect>
+            <rect x="157" y="473" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="493">RSHIFT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONCAT" xlink:title="CONCAT">
+            <rect x="159" y="519" width="72" height="32"></rect>
+            <rect x="157" y="517" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="537">CONCAT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#JSON_EXTRACT_OP" xlink:title="JSON_EXTRACT_OP">
+            <rect x="159" y="563" width="140" height="32"></rect>
+            <rect x="157" y="561" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="581">JSON_EXTRACT_OP</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#JSON_UNQUOTE_EXTRACT_OP" xlink:title="JSON_UNQUOTE_EXTRACT_OP">
+            <rect x="159" y="607" width="210" height="32"></rect>
+            <rect x="157" y="605" width="210" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="625">JSON_UNQUOTE_EXTRACT_OP</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ANDOP" xlink:title="ANDOP">
+            <rect x="159" y="651" width="64" height="32"></rect>
+            <rect x="157" y="649" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="669">ANDOP</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#OR" xlink:title="OR">
+            <rect x="159" y="695" width="38" height="32"></rect>
+            <rect x="157" y="693" width="38" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="713">OR</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS" xlink:title="IS">
+            <rect x="159" y="739" width="32" height="32"></rect>
+            <rect x="157" y="737" width="32" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="757">IS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ISNOT" xlink:title="ISNOT">
+            <rect x="231" y="771" width="58" height="32"></rect>
+            <rect x="229" y="769" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="789">ISNOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="409" y="123" width="48" height="32"></rect>
+            <rect x="407" y="121" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="417" y="141">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#cmp_op" xlink:title="cmp_op">
+            <rect x="139" y="815" width="70" height="32"></rect>
+            <rect x="137" y="813" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="833">cmp_op</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="229" y="815" width="48" height="32"></rect>
+            <rect x="227" y="813" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="237" y="833">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="297" y="815" width="46" height="32"></rect>
+            <rect x="295" y="813" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="305" y="833">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IS" xlink:title="IS">
+            <rect x="363" y="815" width="32" height="32"></rect>
+            <rect x="361" y="813" width="32" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="371" y="833">IS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#cmp_inequality_op" xlink:title="cmp_inequality_op">
+            <rect x="139" y="859" width="140" height="32"></rect>
+            <rect x="137" y="857" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="877">cmp_inequality_op</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="299" y="859" width="48" height="32"></rect>
+            <rect x="297" y="857" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="877">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="367" y="859" width="46" height="32"></rect>
+            <rect x="365" y="857" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="375" y="877">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INEQUALITY" xlink:title="INEQUALITY">
+            <rect x="433" y="859" width="94" height="32"></rect>
+            <rect x="431" y="857" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="441" y="877">INEQUALITY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#like_op" xlink:title="like_op">
+            <rect x="139" y="903" width="66" height="32"></rect>
+            <rect x="137" y="901" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="921">like_op</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="225" y="903" width="48" height="32"></rect>
+            <rect x="223" y="901" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="921">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ESCAPE" xlink:title="ESCAPE">
+            <rect x="313" y="935" width="68" height="32"></rect>
+            <rect x="311" y="933" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="321" y="953">ESCAPE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="401" y="935" width="48" height="32"></rect>
+            <rect x="399" y="933" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="409" y="953">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="489" y="903" width="46" height="32"></rect>
+            <rect x="487" y="901" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="497" y="921">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LIKE" xlink:title="LIKE">
+            <rect x="555" y="903" width="48" height="32"></rect>
+            <rect x="553" y="901" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="563" y="921">LIKE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ISNULL" xlink:title="ISNULL">
+            <rect x="139" y="979" width="64" height="32"></rect>
+            <rect x="137" y="977" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="997">ISNULL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOTNULL" xlink:title="NOTNULL">
+            <rect x="139" y="1023" width="76" height="32"></rect>
+            <rect x="137" y="1021" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="1041">NOTNULL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="139" y="1067" width="44" height="32"></rect>
+            <rect x="137" y="1065" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="1085">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NULL" xlink:title="NULL">
+            <rect x="223" y="1067" width="52" height="32"></rect>
+            <rect x="221" y="1065" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="1085">NULL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IN" xlink:title="IN">
+            <rect x="223" y="1111" width="34" height="32"></rect>
+            <rect x="221" y="1109" width="34" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="1129">IN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#col_tuple" xlink:title="col_tuple">
+            <rect x="277" y="1111" width="78" height="32"></rect>
+            <rect x="275" y="1109" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="285" y="1129">col_tuple</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#between_op" xlink:title="between_op">
+            <rect x="139" y="1155" width="98" height="32"></rect>
+            <rect x="137" y="1153" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="1173">between_op</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="257" y="1155" width="48" height="32"></rect>
+            <rect x="255" y="1153" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="1173">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AND" xlink:title="AND">
+            <rect x="325" y="1155" width="46" height="32"></rect>
+            <rect x="323" y="1153" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="1173">AND</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="391" y="1155" width="48" height="32"></rect>
+            <rect x="389" y="1153" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="399" y="1173">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="459" y="1155" width="46" height="32"></rect>
+            <rect x="457" y="1153" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="467" y="1173">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BETWEEN" xlink:title="BETWEEN">
+            <rect x="525" y="1155" width="80" height="32"></rect>
+            <rect x="523" y="1153" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="533" y="1173">BETWEEN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#COLLATE" xlink:title="COLLATE">
+            <rect x="139" y="1199" width="76" height="32"></rect>
+            <rect x="137" y="1197" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="1217">COLLATE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="235" y="1199" width="76" height="32"></rect>
+            <rect x="233" y="1197" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="1217">identifier</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IN" xlink:title="IN">
+            <rect x="139" y="1243" width="34" height="32"></rect>
+            <rect x="137" y="1241" width="34" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="1261">IN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#col_tuple" xlink:title="col_tuple">
+            <rect x="193" y="1243" width="78" height="32"></rect>
+            <rect x="191" y="1241" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="1261">col_tuple</text></a><rect x="71" y="1287" width="26" height="32" rx="10"></rect>
+         <rect x="69" y="1285" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1305">-</text>
+         <rect x="71" y="1331" width="30" height="32" rx="10"></rect>
+         <rect x="69" y="1329" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1349">+</text>
+         <rect x="71" y="1375" width="30" height="32" rx="10"></rect>
+         <rect x="69" y="1373" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1393">~</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="141" y="1287" width="48" height="32"></rect>
+            <rect x="139" y="1285" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="1305">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="209" y="1287" width="46" height="32"></rect>
+            <rect x="207" y="1285" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="1305">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UNARY" xlink:title="UNARY">
+            <rect x="275" y="1287" width="62" height="32"></rect>
+            <rect x="273" y="1285" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="283" y="1305">UNARY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CASE" xlink:title="CASE">
+            <rect x="51" y="1441" width="52" height="32"></rect>
+            <rect x="49" y="1439" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1459">CASE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_opt" xlink:title="expr_opt">
+            <rect x="123" y="1441" width="76" height="32"></rect>
+            <rect x="121" y="1439" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="131" y="1459">expr_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#when" xlink:title="when">
+            <rect x="239" y="1441" width="54" height="32"></rect>
+            <rect x="237" y="1439" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="1459">when</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#else_expr_opt" xlink:title="else_expr_opt">
+            <rect x="333" y="1441" width="112" height="32"></rect>
+            <rect x="331" y="1439" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="341" y="1459">else_expr_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#END" xlink:title="END">
+            <rect x="465" y="1441" width="46" height="32"></rect>
+            <rect x="463" y="1439" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="473" y="1459">END</text></a><rect x="71" y="1485" width="26" height="32" rx="10"></rect>
+         <rect x="69" y="1483" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="1503">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="117" y="1485" width="48" height="32"></rect>
+            <rect x="115" y="1483" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="125" y="1503">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CAST" xlink:title="CAST">
+            <rect x="71" y="1529" width="52" height="32"></rect>
+            <rect x="69" y="1527" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="1547">CAST</text></a><rect x="143" y="1529" width="26" height="32" rx="10"></rect>
+         <rect x="141" y="1527" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="1547">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="189" y="1529" width="48" height="32"></rect>
+            <rect x="187" y="1527" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="1547">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AS" xlink:title="AS">
+            <rect x="257" y="1529" width="36" height="32"></rect>
+            <rect x="255" y="1527" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="1547">AS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#convert_type" xlink:title="convert_type">
+            <rect x="313" y="1529" width="104" height="32"></rect>
+            <rect x="311" y="1527" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="321" y="1547">convert_type</text></a><rect x="457" y="1485" width="26" height="32" rx="10"></rect>
+         <rect x="455" y="1483" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="465" y="1503">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#subquery" xlink:title="subquery">
+            <rect x="51" y="1573" width="78" height="32"></rect>
+            <rect x="49" y="1571" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1591">subquery</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#exists_subquery" xlink:title="exists_subquery">
+            <rect x="51" y="1617" width="124" height="32"></rect>
+            <rect x="49" y="1615" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1635">exists_subquery</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#function_call_keyword" xlink:title="function_call_keyword">
+            <rect x="51" y="1661" width="160" height="32"></rect>
+            <rect x="49" y="1659" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1679">function_call_keyword</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#function_call_generic" xlink:title="function_call_generic">
+            <rect x="51" y="1705" width="154" height="32"></rect>
+            <rect x="49" y="1703" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1723">function_call_generic</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m98 0 h10 m0 0 h476 m-614 0 h20 m594 0 h20 m-634 0 q10 0 10 10 m614 0 q0 -10 10 -10 m-624 10 v24 m614 0 v-24 m-614 24 q0 10 10 10 m594 0 q10 0 10 -10 m-584 10 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m96 0 h10 m0 0 h10 m24 0 h10 m20 -32 h10 m108 0 h10 m0 0 h266 m-604 -10 v20 m614 0 v-20 m-614 20 v56 m614 0 v-56 m-614 56 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m48 0 h10 m40 0 h10 m30 0 h10 m0 0 h180 m-250 0 h20 m230 0 h20 m-270 0 q10 0 10 10 m250 0 q0 -10 10 -10 m-260 10 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m26 0 h10 m0 0 h184 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m28 0 h10 m0 0 h182 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m28 0 h10 m0 0 h182 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m20 0 h10 m0 0 h190 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m30 0 h10 m0 0 h180 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m26 0 h10 m0 0 h184 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m62 0 h10 m0 0 h148 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m64 0 h10 m0 0 h146 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m72 0 h10 m0 0 h138 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m140 0 h10 m0 0 h70 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m210 0 h10 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m64 0 h10 m0 0 h146 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m38 0 h10 m0 0 h172 m-240 -10 v20 m250 0 v-20 m-250 20 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m32 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h60 m20 -616 h10 m48 0 h10 m0 0 h148 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v672 m506 0 v-672 m-506 672 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m32 0 h10 m0 0 h210 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m140 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m94 0 h10 m0 0 h78 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m66 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m68 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m46 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m-496 -10 v20 m506 0 v-20 m-506 20 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m64 0 h10 m0 0 h402 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m76 0 h10 m0 0 h390 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m44 0 h10 m20 0 h10 m52 0 h10 m0 0 h80 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m34 0 h10 m0 0 h10 m78 0 h10 m20 -44 h230 m-496 -10 v20 m506 0 v-20 m-506 20 v68 m506 0 v-68 m-506 68 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m98 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m80 0 h10 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m76 0 h10 m0 0 h10 m76 0 h10 m0 0 h294 m-496 -10 v20 m506 0 v-20 m-506 20 v24 m506 0 v-24 m-506 24 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m34 0 h10 m0 0 h10 m78 0 h10 m0 0 h334 m-584 -1130 v20 m614 0 v-20 m-614 20 v1144 m614 0 v-1144 m-614 1144 q0 10 10 10 m594 0 q10 0 10 -10 m-584 10 h10 m26 0 h10 m0 0 h4 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m-60 -10 v20 m70 0 v-20 m-70 20 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -88 h10 m48 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m0 0 h288 m-604 -10 v20 m614 0 v-20 m-614 20 v134 m614 0 v-134 m-614 134 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m52 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m54 0 h10 m-94 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m74 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-74 0 h10 m0 0 h64 m20 32 h10 m112 0 h10 m0 0 h10 m46 0 h10 m0 0 h114 m-604 -10 v20 m614 0 v-20 m-614 20 v24 m614 0 v-24 m-614 24 q0 10 10 10 m594 0 q10 0 10 -10 m-584 10 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h252 m-386 0 h20 m366 0 h20 m-406 0 q10 0 10 10 m386 0 q0 -10 10 -10 m-396 10 v24 m386 0 v-24 m-386 24 q0 10 10 10 m366 0 q10 0 10 -10 m-376 10 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m104 0 h10 m20 -44 h10 m26 0 h10 m0 0 h142 m-604 -10 v20 m614 0 v-20 m-614 20 v68 m614 0 v-68 m-614 68 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m78 0 h10 m0 0 h496 m-604 -10 v20 m614 0 v-20 m-614 20 v24 m614 0 v-24 m-614 24 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m124 0 h10 m0 0 h450 m-604 -10 v20 m614 0 v-20 m-614 20 v24 m614 0 v-24 m-614 24 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m160 0 h10 m0 0 h414 m-604 -10 v20 m614 0 v-20 m-614 20 v24 m614 0 v-24 m-614 24 q0 10 10 10 m594 0 q10 0 10 -10 m-604 10 h10 m154 0 h10 m0 0 h420 m23 -1702 h-3"></svg:path>
+         <polygon points="663 17 671 13 671 21"></polygon>
+         <polygon points="663 17 655 13 655 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#else_expr_opt" title="else_expr_opt">else_expr_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr_list" title="expr_list">expr_list</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr_opt" title="expr_opt">expr_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#filter_opt" title="filter_opt">filter_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#function_call_keyword" title="function_call_keyword">function_call_keyword</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#having_opt" title="having_opt">having_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#join_constraint" title="join_constraint">join_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#limit_opt" title="limit_opt">limit_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#ordering_term" title="ordering_term">ordering_term</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#select_column" title="select_column">select_column</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_constraint" title="table_constraint">table_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#update_expression" title="update_expression">update_expression</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#when" title="when">when</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#where_opt" title="where_opt">where_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="literal_value">literal_value:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="213" height="257">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#numeric_literal" xlink:title="numeric_literal">
+            <rect x="51" y="3" width="114" height="32"></rect>
+            <rect x="49" y="1" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">numeric_literal</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="47" width="66" height="32"></rect>
+            <rect x="49" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">STRING</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BLOBVAL" xlink:title="BLOBVAL">
+            <rect x="51" y="91" width="76" height="32"></rect>
+            <rect x="49" y="89" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">BLOBVAL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TRUE" xlink:title="TRUE">
+            <rect x="51" y="135" width="52" height="32"></rect>
+            <rect x="49" y="133" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">TRUE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FALSE" xlink:title="FALSE">
+            <rect x="51" y="179" width="58" height="32"></rect>
+            <rect x="49" y="177" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">FALSE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NULL" xlink:title="NULL">
+            <rect x="51" y="223" width="52" height="32"></rect>
+            <rect x="49" y="221" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">NULL</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m114 0 h10 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m66 0 h10 m0 0 h48 m-144 -10 v20 m154 0 v-20 m-154 20 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m76 0 h10 m0 0 h38 m-144 -10 v20 m154 0 v-20 m-154 20 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m52 0 h10 m0 0 h62 m-144 -10 v20 m154 0 v-20 m-154 20 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m58 0 h10 m0 0 h56 m-144 -10 v20 m154 0 v-20 m-154 20 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m52 0 h10 m0 0 h62 m23 -220 h-3"></svg:path>
+         <polygon points="203 17 211 13 211 21"></polygon>
+         <polygon points="203 17 195 13 195 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_name">column_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="135" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="31" y="3" width="76" height="32"></rect>
+            <rect x="29" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">identifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="125 17 133 13 133 21"></polygon>
+         <polygon points="125 17 117 13 117 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_def" title="column_def">column_def</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#column_name_list" title="column_name_list">column_name_list</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#update_expression" title="update_expression">update_expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_name_list">column_name_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="207" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name" xlink:title="column_name">
+            <rect x="51" y="47" width="108" height="32"></rect>
+            <rect x="49" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">column_name</text></a><rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m108 0 h10 m-148 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m128 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-128 0 h10 m24 0 h10 m0 0 h84 m23 44 h-3"></svg:path>
+         <polygon points="197 61 205 57 205 65"></polygon>
+         <polygon points="197 61 189 57 189 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_name_list_opt" title="column_name_list_opt">column_name_list_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#join_constraint" title="join_constraint">join_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#paren_update_list" title="paren_update_list">paren_update_list</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_constraint" title="table_constraint">table_constraint</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="cmp_op">cmp_op:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="313" height="213">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NE" xlink:title="NE">
+            <rect x="51" y="47" width="36" height="32"></rect>
+            <rect x="49" y="45" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">NE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="71" y="123" width="44" height="32"></rect>
+            <rect x="69" y="121" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="141">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REGEXP" xlink:title="REGEXP">
+            <rect x="175" y="91" width="70" height="32"></rect>
+            <rect x="173" y="89" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="183" y="109">REGEXP</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GLOB" xlink:title="GLOB">
+            <rect x="175" y="135" width="54" height="32"></rect>
+            <rect x="173" y="133" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="183" y="153">GLOB</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#MATCH" xlink:title="MATCH">
+            <rect x="175" y="179" width="62" height="32"></rect>
+            <rect x="173" y="177" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="183" y="197">MATCH</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m30 0 h10 m0 0 h184 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v24 m254 0 v-24 m-254 24 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m36 0 h10 m0 0 h178 m-244 -10 v20 m254 0 v-20 m-254 20 v24 m254 0 v-24 m-254 24 q0 10 10 10 m234 0 q10 0 10 -10 m-224 10 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m40 -32 h10 m70 0 h10 m-110 0 h20 m90 0 h20 m-130 0 q10 0 10 10 m110 0 q0 -10 10 -10 m-120 10 v24 m110 0 v-24 m-110 24 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m54 0 h10 m0 0 h16 m-100 -10 v20 m110 0 v-20 m-110 20 v24 m110 0 v-24 m-110 24 q0 10 10 10 m90 0 q10 0 10 -10 m-100 10 h10 m62 0 h10 m0 0 h8 m43 -176 h-3"></svg:path>
+         <polygon points="303 17 311 13 311 21"></polygon>
+         <polygon points="303 17 295 13 295 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="cmp_inequality_op">cmp_inequality_op:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="135" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">&lt;</text>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">&gt;</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LE" xlink:title="LE">
+            <rect x="51" y="91" width="34" height="32"></rect>
+            <rect x="49" y="89" width="34" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">LE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GE" xlink:title="GE">
+            <rect x="51" y="135" width="36" height="32"></rect>
+            <rect x="49" y="133" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">GE</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m30 0 h10 m0 0 h6 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m30 0 h10 m0 0 h6 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m34 0 h10 m0 0 h2 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m36 0 h10 m23 -132 h-3"></svg:path>
+         <polygon points="125 17 133 13 133 21"></polygon>
+         <polygon points="125 17 117 13 117 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="like_op">like_op:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="211" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="51" y="35" width="44" height="32"></rect>
+            <rect x="49" y="33" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="53">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LIKE" xlink:title="LIKE">
+            <rect x="135" y="3" width="48" height="32"></rect>
+            <rect x="133" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="21">LIKE</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="201 17 209 13 209 21"></polygon>
+         <polygon points="201 17 193 13 193 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="between_op">between_op:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="243" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="51" y="35" width="44" height="32"></rect>
+            <rect x="49" y="33" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="53">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BETWEEN" xlink:title="BETWEEN">
+            <rect x="135" y="3" width="80" height="32"></rect>
+            <rect x="133" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="21">BETWEEN</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m80 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="233 17 241 13 241 21"></polygon>
+         <polygon points="233 17 225 13 225 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="convert_type">convert_type:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="177" height="213">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NONE" xlink:title="NONE">
+            <rect x="51" y="3" width="54" height="32"></rect>
+            <rect x="49" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">NONE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TEXT" xlink:title="TEXT">
+            <rect x="51" y="47" width="50" height="32"></rect>
+            <rect x="49" y="45" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">TEXT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REAL" xlink:title="REAL">
+            <rect x="51" y="91" width="52" height="32"></rect>
+            <rect x="49" y="89" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">REAL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INTEGER" xlink:title="INTEGER">
+            <rect x="51" y="135" width="74" height="32"></rect>
+            <rect x="49" y="133" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">INTEGER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NUMERIC" xlink:title="NUMERIC">
+            <rect x="51" y="179" width="78" height="32"></rect>
+            <rect x="49" y="177" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">NUMERIC</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h24 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m50 0 h10 m0 0 h28 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m52 0 h10 m0 0 h26 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m74 0 h10 m0 0 h4 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -176 h-3"></svg:path>
+         <polygon points="167 17 175 13 175 21"></polygon>
+         <polygon points="167 17 159 13 159 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="col_tuple">col_tuple:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="305" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="117" y="35" width="74" height="32"></rect>
+            <rect x="115" y="33" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="125" y="53">expr_list</text></a><rect x="231" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="229" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="239" y="21">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#subquery" xlink:title="subquery">
+            <rect x="51" y="79" width="78" height="32"></rect>
+            <rect x="49" y="77" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="97">subquery</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m26 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m26 0 h10 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v56 m246 0 v-56 m-246 56 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m78 0 h10 m0 0 h128 m23 -76 h-3"></svg:path>
+         <polygon points="295 17 303 13 303 21"></polygon>
+         <polygon points="295 17 287 13 287 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="subquery">subquery:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="245" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="77" y="3" width="94" height="32"></rect>
+            <rect x="75" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="85" y="21">select_stmt</text></a><rect x="191" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="189" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="199" y="21">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="235 17 243 13 243 21"></polygon>
+         <polygon points="235 17 227 13 227 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#col_tuple" title="col_tuple">col_tuple</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#exists_subquery" title="exists_subquery">exists_subquery</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="exists_subquery">exists_subquery:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="325" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="51" y="35" width="44" height="32"></rect>
+            <rect x="49" y="33" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="53">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#EXISTS" xlink:title="EXISTS">
+            <rect x="135" y="3" width="64" height="32"></rect>
+            <rect x="133" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="21">EXISTS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#subquery" xlink:title="subquery">
+            <rect x="219" y="3" width="78" height="32"></rect>
+            <rect x="217" y="1" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="227" y="21">subquery</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m64 0 h10 m0 0 h10 m78 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="315 17 323 13 323 21"></polygon>
+         <polygon points="315 17 307 13 307 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="function_call_keyword">function_call_keyword:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="571" height="113">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GLOB" xlink:title="GLOB">
+            <rect x="51" y="3" width="54" height="32"></rect>
+            <rect x="49" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">GLOB</text></a><rect x="125" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#LIKE" xlink:title="LIKE">
+            <rect x="51" y="47" width="48" height="32"></rect>
+            <rect x="49" y="45" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">LIKE</text></a><rect x="119" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="117" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="65">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="185" y="79" width="48" height="32"></rect>
+            <rect x="183" y="77" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="97">expr</text></a><rect x="253" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="251" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="97">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="337" y="3" width="48" height="32"></rect>
+            <rect x="335" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="21">expr</text></a><rect x="405" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="403" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="413" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="449" y="3" width="48" height="32"></rect>
+            <rect x="447" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="457" y="21">expr</text></a><rect x="517" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="515" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="525" y="21">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m0 0 h146 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v24 m286 0 v-24 m-286 24 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m48 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h102 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v12 m132 0 v-12 m-132 12 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m48 0 h10 m0 0 h10 m24 0 h10 m40 -76 h10 m48 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="561 17 569 13 569 21"></polygon>
+         <polygon points="561 17 553 13 553 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="function_call_generic">function_call_generic:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="663" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="31" y="3" width="76" height="32"></rect>
+            <rect x="29" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">identifier</text></a><rect x="127" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="125" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="135" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#distinct_function_opt" xlink:title="distinct_function_opt">
+            <rect x="193" y="3" width="154" height="32"></rect>
+            <rect x="191" y="1" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="21">distinct_function_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list_opt" xlink:title="expr_list_opt">
+            <rect x="367" y="3" width="104" height="32"></rect>
+            <rect x="365" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="375" y="21">expr_list_opt</text></a><rect x="193" y="47" width="28" height="32" rx="10"></rect>
+         <rect x="191" y="45" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="201" y="65">*</text>
+         <rect x="511" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="509" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="519" y="21">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#filter_opt" xlink:title="filter_opt">
+            <rect x="557" y="3" width="78" height="32"></rect>
+            <rect x="555" y="1" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="565" y="21">filter_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m154 0 h10 m0 0 h10 m104 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m28 0 h10 m0 0 h250 m20 -44 h10 m26 0 h10 m0 0 h10 m78 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="653 17 661 13 661 21"></polygon>
+         <polygon points="653 17 645 13 645 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="distinct_function_opt">distinct_function_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="177" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DISTINCT" xlink:title="DISTINCT">
+            <rect x="51" y="23" width="78" height="32"></rect>
+            <rect x="49" y="21" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">DISTINCT</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="167 5 175 1 175 9"></polygon>
+         <polygon points="167 5 159 1 159 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#function_call_generic" title="function_call_generic">function_call_generic</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="expr_list">expr_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="147" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="51" y="47" width="48" height="32"></rect>
+            <rect x="49" y="45" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">expr</text></a><rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m48 0 h10 m-88 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m68 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-68 0 h10 m24 0 h10 m0 0 h24 m23 44 h-3"></svg:path>
+         <polygon points="137 61 145 57 145 65"></polygon>
+         <polygon points="137 61 129 57 129 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#col_tuple" title="col_tuple">col_tuple</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr_list_opt" title="expr_list_opt">expr_list_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#group_by_opt" title="group_by_opt">group_by_opt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#insert_stmt" title="insert_stmt">insert_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#paren_update_list" title="paren_update_list">paren_update_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="expr_list_opt">expr_list_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="173" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="51" y="23" width="74" height="32"></rect>
+            <rect x="49" y="21" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">expr_list</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="163 5 171 1 171 9"></polygon>
+         <polygon points="163 5 155 1 155 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#function_call_generic" title="function_call_generic">function_call_generic</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="filter_opt">filter_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="407" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FILTER" xlink:title="FILTER">
+            <rect x="51" y="23" width="62" height="32"></rect>
+            <rect x="49" y="21" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">FILTER</text></a><rect x="133" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="131" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="41">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#WHERE" xlink:title="WHERE">
+            <rect x="179" y="23" width="66" height="32"></rect>
+            <rect x="177" y="21" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="187" y="41">WHERE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="265" y="23" width="48" height="32"></rect>
+            <rect x="263" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="273" y="41">expr</text></a><rect x="333" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="331" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="341" y="41">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h318 m-348 0 h20 m328 0 h20 m-368 0 q10 0 10 10 m348 0 q0 -10 10 -10 m-358 10 v12 m348 0 v-12 m-348 12 q0 10 10 10 m328 0 q10 0 10 -10 m-338 10 h10 m62 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="397 5 405 1 405 9"></polygon>
+         <polygon points="397 5 389 1 389 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#function_call_generic" title="function_call_generic">function_call_generic</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="expr_opt">expr_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="147" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="51" y="23" width="48" height="32"></rect>
+            <rect x="49" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="137 5 145 1 145 9"></polygon>
+         <polygon points="137 5 129 1 129 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="when">when:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="325" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#WHEN" xlink:title="WHEN">
+            <rect x="31" y="3" width="58" height="32"></rect>
+            <rect x="29" y="1" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">WHEN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="109" y="3" width="48" height="32"></rect>
+            <rect x="107" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="117" y="21">expr</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#THEN" xlink:title="THEN">
+            <rect x="177" y="3" width="52" height="32"></rect>
+            <rect x="175" y="1" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="185" y="21">THEN</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="249" y="3" width="48" height="32"></rect>
+            <rect x="247" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="257" y="21">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="315 17 323 13 323 21"></polygon>
+         <polygon points="315 17 307 13 307 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="else_expr_opt">else_expr_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="217" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ELSE" xlink:title="ELSE">
+            <rect x="51" y="23" width="50" height="32"></rect>
+            <rect x="49" y="21" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">ELSE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="121" y="23" width="48" height="32"></rect>
+            <rect x="119" y="21" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="41">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m50 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="207 5 215 1 215 9"></polygon>
+         <polygon points="207 5 199 1 199 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="create_table_stmt">create_table_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="765" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CREATE" xlink:title="CREATE">
+            <rect x="31" y="47" width="68" height="32"></rect>
+            <rect x="29" y="45" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="65">CREATE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TABLE" xlink:title="TABLE">
+            <rect x="119" y="47" width="58" height="32"></rect>
+            <rect x="117" y="45" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="127" y="65">TABLE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="197" y="47" width="96" height="32"></rect>
+            <rect x="195" y="45" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="65">table_name</text></a><rect x="313" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="311" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="65">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_def" xlink:title="column_def">
+            <rect x="379" y="47" width="92" height="32"></rect>
+            <rect x="377" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="387" y="65">column_def</text></a><rect x="379" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="377" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="387" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_constraint_list_opt" xlink:title="table_constraint_list_opt">
+            <rect x="511" y="47" width="180" height="32"></rect>
+            <rect x="509" y="45" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="519" y="65">table_constraint_list_opt</text></a><rect x="711" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="709" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="719" y="65">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m0 0 h10 m68 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m92 0 h10 m-132 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m112 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-112 0 h10 m24 0 h10 m0 0 h68 m20 44 h10 m180 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="755 61 763 57 763 65"></polygon>
+         <polygon points="755 61 747 57 747 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#single_stmt" title="single_stmt">single_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_def">column_def:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="471" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name" xlink:title="column_name">
+            <rect x="31" y="3" width="108" height="32"></rect>
+            <rect x="29" y="1" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">column_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#type_name" xlink:title="type_name">
+            <rect x="159" y="3" width="92" height="32"></rect>
+            <rect x="157" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="21">type_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_constraints_opt" xlink:title="column_constraints_opt">
+            <rect x="271" y="3" width="172" height="32"></rect>
+            <rect x="269" y="1" width="172" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="279" y="21">column_constraints_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m108 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m172 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="461 17 469 13 469 21"></polygon>
+         <polygon points="461 17 453 13 453 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="type_name">type_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="173" height="257">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INT" xlink:title="INT">
+            <rect x="51" y="3" width="40" height="32"></rect>
+            <rect x="49" y="1" width="40" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">INT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INTEGER" xlink:title="INTEGER">
+            <rect x="51" y="47" width="74" height="32"></rect>
+            <rect x="49" y="45" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">INTEGER</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REAL" xlink:title="REAL">
+            <rect x="51" y="91" width="52" height="32"></rect>
+            <rect x="49" y="89" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">REAL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TEXT" xlink:title="TEXT">
+            <rect x="51" y="135" width="50" height="32"></rect>
+            <rect x="49" y="133" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">TEXT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#BLOB" xlink:title="BLOB">
+            <rect x="51" y="179" width="52" height="32"></rect>
+            <rect x="49" y="177" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">BLOB</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ANY" xlink:title="ANY">
+            <rect x="51" y="223" width="44" height="32"></rect>
+            <rect x="49" y="221" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">ANY</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m40 0 h10 m0 0 h34 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m-104 -10 v20 m114 0 v-20 m-114 20 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m52 0 h10 m0 0 h22 m-104 -10 v20 m114 0 v-20 m-114 20 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m50 0 h10 m0 0 h24 m-104 -10 v20 m114 0 v-20 m-114 20 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m52 0 h10 m0 0 h22 m-104 -10 v20 m114 0 v-20 m-114 20 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m44 0 h10 m0 0 h30 m23 -220 h-3"></svg:path>
+         <polygon points="163 17 171 13 171 21"></polygon>
+         <polygon points="163 17 155 13 155 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_def" title="column_def">column_def</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_constraints_opt">column_constraints_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="235" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_constraint" xlink:title="column_constraint">
+            <rect x="51" y="3" width="136" height="32"></rect>
+            <rect x="49" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">column_constraint</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 51 h2 m20 0 h10 m0 0 h146 m-176 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m156 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-156 0 h10 m136 0 h10 m23 34 h-3"></svg:path>
+         <polygon points="225 51 233 47 233 55"></polygon>
+         <polygon points="225 51 217 47 217 55"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_def" title="column_def">column_def</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_constraint">column_constraint:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="785" height="377">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#constraint_name" xlink:title="constraint_name">
+            <rect x="31" y="3" width="126" height="32"></rect>
+            <rect x="29" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">constraint_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PRIMARY" xlink:title="PRIMARY">
+            <rect x="197" y="3" width="74" height="32"></rect>
+            <rect x="195" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="21">PRIMARY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#KEY" xlink:title="KEY">
+            <rect x="291" y="3" width="44" height="32"></rect>
+            <rect x="289" y="1" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="299" y="21">KEY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#primary_key_order" xlink:title="primary_key_order">
+            <rect x="355" y="3" width="140" height="32"></rect>
+            <rect x="353" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="363" y="21">primary_key_order</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NOT" xlink:title="NOT">
+            <rect x="197" y="47" width="44" height="32"></rect>
+            <rect x="195" y="45" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="65">NOT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#NULL" xlink:title="NULL">
+            <rect x="261" y="47" width="52" height="32"></rect>
+            <rect x="259" y="45" width="52" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="269" y="65">NULL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UNIQUE" xlink:title="UNIQUE">
+            <rect x="197" y="91" width="68" height="32"></rect>
+            <rect x="195" y="89" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="109">UNIQUE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CHECK" xlink:title="CHECK">
+            <rect x="197" y="135" width="62" height="32"></rect>
+            <rect x="195" y="133" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="153">CHECK</text></a><rect x="279" y="135" width="26" height="32" rx="10"></rect>
+         <rect x="277" y="133" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="153">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="325" y="135" width="48" height="32"></rect>
+            <rect x="323" y="133" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="153">expr</text></a><rect x="393" y="135" width="26" height="32" rx="10"></rect>
+         <rect x="391" y="133" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="401" y="153">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DEFAULT" xlink:title="DEFAULT">
+            <rect x="197" y="179" width="74" height="32"></rect>
+            <rect x="195" y="177" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="197">DEFAULT</text></a><rect x="311" y="179" width="26" height="32" rx="10"></rect>
+         <rect x="309" y="177" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="197">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="357" y="179" width="48" height="32"></rect>
+            <rect x="355" y="177" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="365" y="197">expr</text></a><rect x="425" y="179" width="26" height="32" rx="10"></rect>
+         <rect x="423" y="177" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="433" y="197">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#literal_value" xlink:title="literal_value">
+            <rect x="311" y="223" width="98" height="32"></rect>
+            <rect x="309" y="221" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="241">literal_value</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#signed_number" xlink:title="signed_number">
+            <rect x="311" y="267" width="118" height="32"></rect>
+            <rect x="309" y="265" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="285">signed_number</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GENERATED" xlink:title="GENERATED">
+            <rect x="217" y="343" width="94" height="32"></rect>
+            <rect x="215" y="341" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="361">GENERATED</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ALWAYS" xlink:title="ALWAYS">
+            <rect x="331" y="343" width="72" height="32"></rect>
+            <rect x="329" y="341" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="339" y="361">ALWAYS</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#AS" xlink:title="AS">
+            <rect x="443" y="311" width="36" height="32"></rect>
+            <rect x="441" y="309" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="451" y="329">AS</text></a><rect x="499" y="311" width="26" height="32" rx="10"></rect>
+         <rect x="497" y="309" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="507" y="329">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="545" y="311" width="48" height="32"></rect>
+            <rect x="543" y="309" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="553" y="329">expr</text></a><rect x="613" y="311" width="26" height="32" rx="10"></rect>
+         <rect x="611" y="309" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="621" y="329">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#is_stored" xlink:title="is_stored">
+            <rect x="659" y="311" width="78" height="32"></rect>
+            <rect x="657" y="309" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="667" y="329">is_stored</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m126 0 h10 m20 0 h10 m74 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m140 0 h10 m0 0 h242 m-580 0 h20 m560 0 h20 m-600 0 q10 0 10 10 m580 0 q0 -10 10 -10 m-590 10 v24 m580 0 v-24 m-580 24 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m44 0 h10 m0 0 h10 m52 0 h10 m0 0 h424 m-570 -10 v20 m580 0 v-20 m-580 20 v24 m580 0 v-24 m-580 24 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m68 0 h10 m0 0 h472 m-570 -10 v20 m580 0 v-20 m-580 20 v24 m580 0 v-24 m-580 24 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m62 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h318 m-570 -10 v20 m580 0 v-20 m-580 20 v24 m580 0 v-24 m-580 24 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m74 0 h10 m20 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m98 0 h10 m0 0 h42 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m118 0 h10 m0 0 h22 m20 -88 h266 m-570 -10 v20 m580 0 v-20 m-580 20 v112 m580 0 v-112 m-580 112 q0 10 10 10 m560 0 q10 0 10 -10 m-550 10 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m94 0 h10 m0 0 h10 m72 0 h10 m20 -32 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m78 0 h10 m23 -308 h-3"></svg:path>
+         <polygon points="775 17 783 13 783 21"></polygon>
+         <polygon points="775 17 767 13 767 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraints_opt" title="column_constraints_opt">column_constraints_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="constraint_name">constraint_name:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="295" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CONSTRAINT" xlink:title="CONSTRAINT">
+            <rect x="51" y="23" width="100" height="32"></rect>
+            <rect x="49" y="21" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">CONSTRAINT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#identifier" xlink:title="identifier">
+            <rect x="171" y="23" width="76" height="32"></rect>
+            <rect x="169" y="21" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="179" y="41">identifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h206 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v12 m236 0 v-12 m-236 12 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m100 0 h10 m0 0 h10 m76 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="285 5 293 1 293 9"></polygon>
+         <polygon points="285 5 277 1 277 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_constraint" title="table_constraint">table_constraint</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="primary_key_order">primary_key_order:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="153" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ASC" xlink:title="ASC">
+            <rect x="51" y="23" width="44" height="32"></rect>
+            <rect x="49" y="21" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">ASC</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DESC" xlink:title="DESC">
+            <rect x="51" y="67" width="54" height="32"></rect>
+            <rect x="49" y="65" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="85">DESC</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m44 0 h10 m0 0 h10 m-84 -10 v20 m94 0 v-20 m-94 20 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m23 -76 h-3"></svg:path>
+         <polygon points="143 5 151 1 151 9"></polygon>
+         <polygon points="143 5 135 1 135 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="signed_number">signed_number:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="407" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">+</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#numeric_literal" xlink:title="numeric_literal">
+            <rect x="101" y="3" width="114" height="32"></rect>
+            <rect x="99" y="1" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="109" y="21">numeric_literal</text></a><rect x="51" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#numeric_literal" xlink:title="numeric_literal">
+            <rect x="97" y="47" width="114" height="32"></rect>
+            <rect x="95" y="45" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="65">numeric_literal</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#prec" xlink:title="prec">
+            <rect x="231" y="47" width="46" height="32"></rect>
+            <rect x="229" y="45" width="46" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="65">prec</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UNARY" xlink:title="UNARY">
+            <rect x="297" y="47" width="62" height="32"></rect>
+            <rect x="295" y="45" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="305" y="65">UNARY</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m30 0 h10 m0 0 h10 m114 0 h10 m0 0 h144 m-348 0 h20 m328 0 h20 m-368 0 q10 0 10 10 m348 0 q0 -10 10 -10 m-358 10 v24 m348 0 v-24 m-348 24 q0 10 10 10 m328 0 q10 0 10 -10 m-338 10 h10 m26 0 h10 m0 0 h10 m114 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m62 0 h10 m23 -44 h-3"></svg:path>
+         <polygon points="397 17 405 13 405 21"></polygon>
+         <polygon points="397 17 389 13 389 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="numeric_literal">numeric_literal:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="181" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INTEGRAL" xlink:title="INTEGRAL">
+            <rect x="51" y="3" width="82" height="32"></rect>
+            <rect x="49" y="1" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">INTEGRAL</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FLOAT" xlink:title="FLOAT">
+            <rect x="51" y="47" width="58" height="32"></rect>
+            <rect x="49" y="45" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">FLOAT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#HEXNUM" xlink:title="HEXNUM">
+            <rect x="51" y="91" width="72" height="32"></rect>
+            <rect x="49" y="89" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">HEXNUM</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m58 0 h10 m0 0 h24 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m72 0 h10 m0 0 h10 m23 -88 h-3"></svg:path>
+         <polygon points="171 17 179 13 179 21"></polygon>
+         <polygon points="171 17 163 13 163 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#literal_value" title="literal_value">literal_value</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#signed_number" title="signed_number">signed_number</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="is_stored">is_stored:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="171" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STORED" xlink:title="STORED">
+            <rect x="51" y="23" width="70" height="32"></rect>
+            <rect x="49" y="21" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">STORED</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#VIRTUAL" xlink:title="VIRTUAL">
+            <rect x="51" y="67" width="72" height="32"></rect>
+            <rect x="49" y="65" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="85">VIRTUAL</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m70 0 h10 m0 0 h2 m-102 -10 v20 m112 0 v-20 m-112 20 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m72 0 h10 m23 -76 h-3"></svg:path>
+         <polygon points="161 5 169 1 169 9"></polygon>
+         <polygon points="161 5 153 1 153 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#column_constraint" title="column_constraint">column_constraint</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_constraint_list_opt">table_constraint_list_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="307" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="71" y="19" width="24" height="32" rx="10"></rect>
+         <rect x="69" y="17" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="37">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_constraint" xlink:title="table_constraint">
+            <rect x="115" y="19" width="124" height="32"></rect>
+            <rect x="113" y="17" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="123" y="37">table_constraint</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m40 0 h10 m24 0 h10 m0 0 h10 m124 0 h10 m-208 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m188 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-188 0 h10 m0 0 h178 m-228 32 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m23 -34 h-3"></svg:path>
+         <polygon points="297 33 305 29 305 37"></polygon>
+         <polygon points="297 33 289 29 289 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="table_constraint">table_constraint:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="669" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#constraint_name" xlink:title="constraint_name">
+            <rect x="31" y="3" width="126" height="32"></rect>
+            <rect x="29" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">constraint_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#PRIMARY" xlink:title="PRIMARY">
+            <rect x="217" y="3" width="74" height="32"></rect>
+            <rect x="215" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="21">PRIMARY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#KEY" xlink:title="KEY">
+            <rect x="311" y="3" width="44" height="32"></rect>
+            <rect x="309" y="1" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="21">KEY</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UNIQUE" xlink:title="UNIQUE">
+            <rect x="217" y="47" width="68" height="32"></rect>
+            <rect x="215" y="45" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="65">UNIQUE</text></a><rect x="395" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="393" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name_list" xlink:title="column_name_list">
+            <rect x="441" y="3" width="134" height="32"></rect>
+            <rect x="439" y="1" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="449" y="21">column_name_list</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CHECK" xlink:title="CHECK">
+            <rect x="197" y="91" width="62" height="32"></rect>
+            <rect x="195" y="89" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="109">CHECK</text></a><rect x="279" y="91" width="26" height="32" rx="10"></rect>
+         <rect x="277" y="89" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="109">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="325" y="91" width="48" height="32"></rect>
+            <rect x="323" y="89" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="109">expr</text></a><rect x="615" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="613" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="623" y="21">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m126 0 h10 m40 0 h10 m74 0 h10 m0 0 h10 m44 0 h10 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m68 0 h10 m0 0 h70 m20 -44 h10 m26 0 h10 m0 0 h10 m134 0 h10 m-418 0 h20 m398 0 h20 m-438 0 q10 0 10 10 m418 0 q0 -10 10 -10 m-428 10 v68 m418 0 v-68 m-418 68 q0 10 10 10 m398 0 q10 0 10 -10 m-408 10 h10 m62 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m48 0 h10 m0 0 h202 m20 -88 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="659 17 667 13 667 21"></polygon>
+         <polygon points="659 17 651 13 651 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#table_constraint_list_opt" title="table_constraint_list_opt">table_constraint_list_opt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="insert_stmt">insert_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="847" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INSERT" xlink:title="INSERT">
+            <rect x="31" y="47" width="64" height="32"></rect>
+            <rect x="29" y="45" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="65">INSERT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INTO" xlink:title="INTO">
+            <rect x="115" y="47" width="50" height="32"></rect>
+            <rect x="113" y="45" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="123" y="65">INTO</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="185" y="47" width="96" height="32"></rect>
+            <rect x="183" y="45" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="65">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name_list_opt" xlink:title="column_name_list_opt">
+            <rect x="321" y="47" width="164" height="32"></rect>
+            <rect x="319" y="45" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="329" y="65">column_name_list_opt</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#VALUES" xlink:title="VALUES">
+            <rect x="505" y="47" width="68" height="32"></rect>
+            <rect x="503" y="45" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="513" y="65">VALUES</text></a><rect x="613" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="611" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="621" y="65">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="659" y="47" width="74" height="32"></rect>
+            <rect x="657" y="45" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="667" y="65">expr_list</text></a><rect x="753" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="751" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="761" y="65">)</text>
+         <rect x="613" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="611" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="621" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DEFAULT" xlink:title="DEFAULT">
+            <rect x="321" y="91" width="74" height="32"></rect>
+            <rect x="319" y="89" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="329" y="109">DEFAULT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#VALUES" xlink:title="VALUES">
+            <rect x="415" y="91" width="68" height="32"></rect>
+            <rect x="413" y="89" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="423" y="109">VALUES</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m0 0 h10 m64 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m96 0 h10 m20 0 h10 m164 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m-498 44 h20 m498 0 h20 m-538 0 q10 0 10 10 m518 0 q0 -10 10 -10 m-528 10 v24 m518 0 v-24 m-518 24 q0 10 10 10 m498 0 q10 0 10 -10 m-508 10 h10 m74 0 h10 m0 0 h10 m68 0 h10 m0 0 h316 m23 -44 h-3"></svg:path>
+         <polygon points="837 61 845 57 845 65"></polygon>
+         <polygon points="837 61 829 57 829 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#multi_stmt" title="multi_stmt">multi_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="column_name_list_opt">column_name_list_opt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="325" height="57">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name_list" xlink:title="column_name_list">
+            <rect x="97" y="23" width="134" height="32"></rect>
+            <rect x="95" y="21" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="41">column_name_list</text></a><rect x="251" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="249" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="41">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 5 h2 m20 0 h10 m0 0 h236 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v12 m266 0 v-12 m-266 12 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m26 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="315 5 323 1 323 9"></polygon>
+         <polygon points="315 5 307 1 307 9"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#insert_stmt" title="insert_stmt">insert_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="delete_stmt">delete_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="423" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DELETE" xlink:title="DELETE">
+            <rect x="31" y="3" width="66" height="32"></rect>
+            <rect x="29" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">DELETE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FROM" xlink:title="FROM">
+            <rect x="117" y="3" width="54" height="32"></rect>
+            <rect x="115" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="125" y="21">FROM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="191" y="3" width="96" height="32"></rect>
+            <rect x="189" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="199" y="21">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_opt" xlink:title="where_opt">
+            <rect x="307" y="3" width="88" height="32"></rect>
+            <rect x="305" y="1" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="315" y="21">where_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m88 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="413 17 421 13 421 21"></polygon>
+         <polygon points="413 17 405 13 405 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#multi_stmt" title="multi_stmt">multi_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="update_stmt">update_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="525" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UPDATE" xlink:title="UPDATE">
+            <rect x="31" y="3" width="68" height="32"></rect>
+            <rect x="29" y="1" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">UPDATE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="119" y="3" width="96" height="32"></rect>
+            <rect x="117" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="127" y="21">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SET" xlink:title="SET">
+            <rect x="235" y="3" width="42" height="32"></rect>
+            <rect x="233" y="1" width="42" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="21">SET</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#update_list" xlink:title="update_list">
+            <rect x="297" y="3" width="92" height="32"></rect>
+            <rect x="295" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="305" y="21">update_list</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#where_opt" xlink:title="where_opt">
+            <rect x="409" y="3" width="88" height="32"></rect>
+            <rect x="407" y="1" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="417" y="21">where_opt</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m42 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m88 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="515 17 523 13 523 21"></polygon>
+         <polygon points="515 17 507 13 507 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#multi_stmt" title="multi_stmt">multi_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="update_list">update_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="281" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#update_expression" xlink:title="update_expression">
+            <rect x="71" y="47" width="142" height="32"></rect>
+            <rect x="69" y="45" width="142" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="65">update_expression</text></a><rect x="71" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#paren_update_list" xlink:title="paren_update_list">
+            <rect x="51" y="91" width="136" height="32"></rect>
+            <rect x="49" y="89" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">paren_update_list</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m40 0 h10 m142 0 h10 m-182 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m162 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-162 0 h10 m24 0 h10 m0 0 h118 m-202 44 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m136 0 h10 m0 0 h46 m23 -44 h-3"></svg:path>
+         <polygon points="271 61 279 57 279 65"></polygon>
+         <polygon points="271 61 263 57 263 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#update_stmt" title="update_stmt">update_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="paren_update_list">paren_update_list:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="521" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name_list" xlink:title="column_name_list">
+            <rect x="77" y="3" width="134" height="32"></rect>
+            <rect x="75" y="1" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="85" y="21">column_name_list</text></a><rect x="231" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="229" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="239" y="21">)</text>
+         <rect x="277" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="275" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="21">=</text>
+         <rect x="327" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="325" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="335" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="373" y="3" width="74" height="32"></rect>
+            <rect x="371" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="381" y="21">expr_list</text></a><rect x="467" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="465" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="475" y="21">)</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#update_list" title="update_list">update_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="update_expression">update_expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="285" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column_name" xlink:title="column_name">
+            <rect x="31" y="3" width="108" height="32"></rect>
+            <rect x="29" y="1" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">column_name</text></a><rect x="159" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="157" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#expr" xlink:title="expr">
+            <rect x="209" y="3" width="48" height="32"></rect>
+            <rect x="207" y="1" width="48" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="21">expr</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m108 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="275 17 283 13 283 21"></polygon>
+         <polygon points="275 17 267 13 267 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#update_list" title="update_list">update_list</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="grant_stmt">grant_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="521" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#GRANT" xlink:title="GRANT">
+            <rect x="31" y="3" width="62" height="32"></rect>
+            <rect x="29" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">GRANT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#privileges" xlink:title="privileges">
+            <rect x="113" y="3" width="80" height="32"></rect>
+            <rect x="111" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="21">privileges</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ON" xlink:title="ON">
+            <rect x="213" y="3" width="38" height="32"></rect>
+            <rect x="211" y="1" width="38" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="221" y="21">ON</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="271" y="3" width="96" height="32"></rect>
+            <rect x="269" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="279" y="21">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#TO" xlink:title="TO">
+            <rect x="387" y="3" width="36" height="32"></rect>
+            <rect x="385" y="1" width="36" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="395" y="21">TO</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#roles" xlink:title="roles">
+            <rect x="443" y="3" width="50" height="32"></rect>
+            <rect x="441" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="451" y="21">roles</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#multi_stmt" title="multi_stmt">multi_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="revoke_stmt">revoke_stmt:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="547" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#REVOKE" xlink:title="REVOKE">
+            <rect x="31" y="3" width="70" height="32"></rect>
+            <rect x="29" y="1" width="70" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">REVOKE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#privileges" xlink:title="privileges">
+            <rect x="121" y="3" width="80" height="32"></rect>
+            <rect x="119" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="21">privileges</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ON" xlink:title="ON">
+            <rect x="221" y="3" width="38" height="32"></rect>
+            <rect x="219" y="1" width="38" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="21">ON</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#table_name" xlink:title="table_name">
+            <rect x="279" y="3" width="96" height="32"></rect>
+            <rect x="277" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="287" y="21">table_name</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#FROM" xlink:title="FROM">
+            <rect x="395" y="3" width="54" height="32"></rect>
+            <rect x="393" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="403" y="21">FROM</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#roles" xlink:title="roles">
+            <rect x="469" y="3" width="50" height="32"></rect>
+            <rect x="467" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="477" y="21">roles</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="537 17 545 13 545 21"></polygon>
+         <polygon points="537 17 529 13 529 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#multi_stmt" title="multi_stmt">multi_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="roles">roles:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="165" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#STRING" xlink:title="STRING">
+            <rect x="51" y="47" width="66" height="32"></rect>
+            <rect x="49" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">STRING</text></a><rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m66 0 h10 m-106 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m86 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-86 0 h10 m24 0 h10 m0 0 h42 m23 44 h-3"></svg:path>
+         <polygon points="155 61 163 57 163 65"></polygon>
+         <polygon points="155 61 147 57 147 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#grant_stmt" title="grant_stmt">grant_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="privileges">privileges:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="173" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#privilege" xlink:title="privilege">
+            <rect x="51" y="47" width="74" height="32"></rect>
+            <rect x="49" y="45" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">privilege</text></a><rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m23 44 h-3"></svg:path>
+         <polygon points="163 61 171 57 171 65"></polygon>
+         <polygon points="163 61 155 57 155 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#grant_stmt" title="grant_stmt">grant_stmt</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="privilege">privilege:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="167" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#INSERT" xlink:title="INSERT">
+            <rect x="51" y="3" width="64" height="32"></rect>
+            <rect x="49" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">INSERT</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UPDATE" xlink:title="UPDATE">
+            <rect x="51" y="47" width="68" height="32"></rect>
+            <rect x="49" y="45" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">UPDATE</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#DELETE" xlink:title="DELETE">
+            <rect x="51" y="91" width="66" height="32"></rect>
+            <rect x="49" y="89" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">DELETE</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h4 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m66 0 h10 m0 0 h2 m23 -88 h-3"></svg:path>
+         <polygon points="157 17 165 13 165 21"></polygon>
+         <polygon points="157 17 149 13 149 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#privileges" title="privileges">privileges</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="identifier">identifier:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="151" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #262626; stroke-width: 1;}
+    .bold-line            {stroke: #0A0A0A; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #0F0F0F; shape-rendering: crispEdges}
+    .filled               {fill: #262626; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0A0A0A;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0D0D0D;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #0F0F0F;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #262626; stroke: #262626;}
+    rect.terminal         {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFFFFF; stroke: #262626; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IDENTIFIER" xlink:title="IDENTIFIER">
+            <rect x="31" y="3" width="92" height="32"></rect>
+            <rect x="29" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">IDENTIFIER</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m92 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="141 17 149 13 149 21"></polygon>
+         <polygon points="141 17 133 13 133 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#col_alias" title="col_alias">col_alias</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#column_name" title="column_name">column_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#constraint_name" title="constraint_name">constraint_name</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#expr" title="expr">expr</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#function_call_generic" title="function_call_generic">function_call_generic</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_alias" title="table_alias">table_alias</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#table_name" title="table_name">table_name</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:hr xmlns:xhtml="http://www.w3.org/1999/xhtml" />
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:table border="0" class="signature">
+            <xhtml:tr>
+               <xhtml:td style="width: 100%"> </xhtml:td>
+               <xhtml:td valign="top">
+                  <xhtml:nobr class="signature">... generated by <xhtml:a name="Railroad-Diagram-Generator" class="signature" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank">RR - Railroad Diagram Generator</xhtml:a></xhtml:nobr>
+               </xhtml:td>
+               <xhtml:td><xhtml:a name="Railroad-Diagram-Generator" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+                        <g transform="scale(0.178)">
+                           <circle cx="45" cy="45" r="45" style="stroke:none; fill:#FFCC00"></circle>
+                           <circle cx="45" cy="45" r="42" style="stroke:#332900; stroke-width:2px; fill:#FFCC00"></circle>
+                           <line x1="15" y1="15" x2="75" y2="75" stroke="#332900" style="stroke-width:9px;"></line>
+                           <line x1="15" y1="75" x2="75" y2="15" stroke="#332900" style="stroke-width:9px;"></line>
+                           <text x="7" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                           <text x="64" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                        </g></svg></xhtml:a></xhtml:td>
+            </xhtml:tr>
+         </xhtml:table>
+      </xhtml:p>
+   </body>
+</html>

--- a/ebnf/main.go
+++ b/ebnf/main.go
@@ -24,14 +24,14 @@ func (s *scanner) scan() {
 			break
 		}
 
-		if s.ch == '}' {
-			s.insideBraces--
+		if s.ch == '{' {
+			s.insideBraces++
 			s.readByte()
 			continue
 		}
 
-		if s.ch == '{' {
-			s.insideBraces++
+		if s.ch == '}' {
+			s.insideBraces--
 			s.readByte()
 			continue
 		}

--- a/ebnf/main.go
+++ b/ebnf/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+type scanner struct {
+	input []byte
+	ch    byte
+	pos   int
+
+	insideBraces int
+}
+
+func (s *scanner) Scan() {
+	s.skipUntilStart()
+	s.readByte() // consume %
+	s.readByte() // consume %
+
+	for {
+		if s.ch == 0 { // end
+			break
+		}
+
+		if s.ch == '}' {
+			s.insideBraces--
+			s.readByte()
+			continue
+		}
+
+		if s.ch == '{' {
+			s.insideBraces++
+			s.readByte()
+			continue
+		}
+
+		if s.insideBraces > 0 || s.ch == '%' || (s.ch == ';' && s.peekByte() != '\'') {
+			s.readByte()
+			continue
+		}
+
+		if s.ch == ':' {
+			fmt.Print(" ::= ")
+		} else {
+			fmt.Print(string(s.ch))
+		}
+
+		s.readByte()
+	}
+}
+
+func (s *scanner) readByte() {
+	if s.pos >= len(s.input) {
+		s.ch = 0
+	} else {
+		s.ch = s.input[s.pos]
+	}
+
+	s.pos += 1
+}
+
+func (s *scanner) peekByte() byte {
+	if s.pos >= len(s.input) {
+		return 0
+	} else {
+		return s.input[s.pos]
+	}
+}
+
+func (s *scanner) skipUntilStart() {
+	for {
+		if s.ch == '%' && s.peekByte() == '%' {
+			break
+		}
+		s.readByte()
+	}
+}
+
+func main() {
+	if len(os.Args) <= 1 {
+		log.Fatalf("grammary as argument expected")
+	}
+
+	dat, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+
+	s := &scanner{}
+	s.input = dat
+	s.readByte()
+
+	s.Scan()
+}

--- a/ebnf/main.go
+++ b/ebnf/main.go
@@ -14,7 +14,7 @@ type scanner struct {
 	insideBraces int
 }
 
-func (s *scanner) Scan() {
+func (s *scanner) scan() {
 	s.skipUntilStart()
 	s.readByte() // consume %
 	s.readByte() // consume %
@@ -80,7 +80,7 @@ func (s *scanner) skipUntilStart() {
 
 func main() {
 	if len(os.Args) <= 1 {
-		log.Fatalf("grammary as argument expected")
+		log.Fatalf("grammar filepath as argument expected")
 	}
 
 	dat, err := os.ReadFile(os.Args[1])
@@ -92,5 +92,5 @@ func main() {
 	s.input = dat
 	s.readByte()
 
-	s.Scan()
+	s.scan()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/tablelandnetwork/sqlparser
 go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.13
-	github.com/stretchr/testify v1.7.2
+	github.com/stretchr/testify v1.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -11,9 +12,12 @@ github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rr/LICENSE/LICENSE.txt
+++ b/rr/LICENSE/LICENSE.txt
@@ -1,0 +1,27 @@
+RR - Railroad Diagram Generator
+
+Copyright 2010-2021 Gunther Rademacher <grd@gmx.net>
+
+Licensed under the Apache 2.0 License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+This distribution also includes
+
+      - Saxon-HE from Saxonica.com
+      - TagSoup
+      - Apache Batik
+      - Apache XML Graphics Commons
+      - Apache XML Commons XML APIs
+
+For their license information see THIRD-PARTY-NOTICES.txt.
+
+Thank you for choosing RR - Railroad Diagram Generator.

--- a/rr/LICENSE/THIRD-PARTY-NOTICES.txt
+++ b/rr/LICENSE/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,727 @@
+
+Dependency License Report for rr 1.63
+
+1. Group: net.sf.saxon  Name: Saxon-HE  Version: 10.3
+
+POM Project URL: http://www.saxonica.com/
+
+POM License: Mozilla Public License Version 2.0 - http://www.mozilla.org/MPL/2.0/
+
+--------------------------------------------------------------------------------
+
+2. Group: org.apache.xmlgraphics  Name: batik-all  Version: 1.14
+
+POM License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Embedded license: 
+
+                    ****************************************                    
+
+                                  Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+                    ****************************************                    
+
+Apache Batik
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This software contains code from the World Wide Web Consortium (W3C) for the 
+Document Object Model API (DOM API) and SVG Document Type Definition (DTD).
+
+This software contains code from the International Organisation for
+Standardization for the definition of character entities used in the software's
+documentation.
+
+This product includes images from the Tango Desktop Project
+(http://tango.freedesktop.org/).
+
+This product includes images from the Pasodoble Icon Theme
+(http://www.jesusda.com/projects/pasodoble).
+
+                    ****************************************                    
+
+The Jar files in this directory start the same application as in the
+parent directory, except they include the Batik Extensions on the jar
+file class path.  This means that that the Batik Extensions will work
+with the applications started by these jar files.
+
+Great care should be used when using the Batik Extensions as these are
+not part of the SVG standard.  If you write content that uses these
+extensions you must be aware that this is not conformant SVG content
+and other SVG renderers will not render these documents.  These
+extensions should only be used in content used in closed systems.
+
+The primary purpose of these extensions is demonstrative and to
+generate feedback to the development of the SVG standard.
+
+--------------------------------------------------------------------------------
+
+3. Group: org.apache.xmlgraphics  Name: xmlgraphics-commons  Version: 2.6
+
+POM Project URL: http://xmlgraphics.apache.org/commons/
+
+POM License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Embedded license: 
+
+                    ****************************************                    
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+                    ****************************************                    
+
+Apache XML Graphics Commons
+Copyright 2006-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+4. Group: org.ccil.cowan.tagsoup  Name: tagsoup  Version: 1.2.1
+
+POM Project URL: http://home.ccil.org/~cowan/XML/tagsoup/
+
+POM License: Apache License 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+
+5. Group: xml-apis  Name: xml-apis-ext  Version: 1.3.04
+
+POM Project URL: http://xml.apache.org/commons/components/external/
+
+POM License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Embedded license: 
+
+                    ****************************************                    
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+                    ****************************************                    
+
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the Apache xml-commons xml-apis      ==
+   ==  distribution.                                                      ==
+   =========================================================================
+
+   Apache XML Commons XML APIs
+   Copyright 2006 The Apache Software Foundation.
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of this software were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+
+--------------------------------------------------------------------------------
+
+
+This report was generated at Sat Mar 13 13:02:42 CET 2021.
+

--- a/rr/README.txt
+++ b/rr/README.txt
@@ -1,0 +1,27 @@
+RR - Railroad Diagram Generator
+
+  version 1.63
+  released Mar 13, 2021
+  from https://bottlecaps.de/rr
+
+Usage: java -jar rr.war {-suppressebnf|-keeprecursion|-nofactoring|-noinline|-noepsilon|-color:COLOR|-offset:OFFSET|-png|-md|-out:FILE|width:PIXELS}... GRAMMAR
+    or java -jar rr.war -gui [-port:PORT]
+
+  -suppressebnf    do not show EBNF next to generated diagrams
+  -keeprecursion   no direct recursion elimination
+  -nofactoring     no left or right factoring
+  -noinline        do not inline nonterminals that derive to single literals
+  -noepsilon       remove nonterminal references that derive to epsilon only
+  -color:COLOR     use COLOR as base color, pattern: #[0-9a-fA-F]{6}
+  -offset:OFFSET   hue offset to secondary color in degrees
+  -png             create HTML+PNG in a ZIP file, rather than XHTML+SVG output
+  -out:FILE        create FILE, rather than writing result to standard output
+  -width:PIXELS    try to break graphics into multiple lines, when width exceeds PIXELS (default 992)
+
+  GRAMMAR          path of grammar, in W3C style EBNF, default encoding (use '-' for stdin)
+
+  -gui             run GUI on http://localhost:8080/
+  -port:PORT       use PORT rather than 8080
+
+rr.war is an executable war file. It can be run with "java -jar" as shown
+above, but it can also be deployed in servlet containers like Tomcat or Jetty.


### PR DESCRIPTION
This PR adds a series of tools for generating syntax diagrams.

Syntax diagrams are also useful for end-user documentation and debugging (sometimes it's easier to look at a visual representation to see if something is wrong).

Tools added:
- The first tool is a custom tool for transforming the YACC grammar into EBNF grammar. That can be found at `ebnf/main.go`.
- The second tool is a Java app that transforms a EBNF grammar into diagrams, downloaded from [Railroad Diagram Generator](https://www.bottlecaps.de/rr/ui). That can be found at the directory `rr`. 

You generate the diagram by running `make generate-diagrams`.
I will execute: 
```go run ebnf/main.go grammar.y | java -jar rr/rr.war -suppressebnf -color:#FFFFFF -out:diagrams.xhtml -```

That means it will first transform `grammar.y` to EBNF format and pass it to `rr.war`, generating a `xhtml` file. 



